### PR TITLE
[Refactor] Nginx 라우팅을 /coinserver prefix로 통합

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,11 +21,11 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256';
 
-    # 1. /coinserver로 시작하는 모든 요청 → 백엔드(8080)로 프록시
-    # /coinserver 프리픽스는 제거하고 나머지 경로만 백엔드로 전달
-    # 예: /coinserver/api/v1/test → http://backend:8080/api/v1/test
-    # 예: /coinserver/swagger-ui/index.html → http://backend:8080/swagger-ui/index.html
-    location /coinserver/ {
+    # 1. /coinsight로 시작하는 모든 요청 → 백엔드(8080)로 프록시
+    # /coinsight 프리픽스는 제거하고 나머지 경로만 백엔드로 전달
+    # 예: /coinsight/api/v1/test → http://backend:8080/api/v1/test
+    # 예: /coinsight/swagger-ui/index.html → http://backend:8080/swagger-ui/index.html
+    location /coinsight/ {
         proxy_pass http://coanalysis-app:8080/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
 - /coinserver/* → 백엔드(8080) 프록시 (prefix 제거)
  - API, Swagger 등 모든 백엔드 경로를 하나의 prefix로 관리
  - 설정 간소화 및 유지보수성 향상"